### PR TITLE
add support for validating worldcup restricted list

### DIFF
--- a/src/DeckValidator.js
+++ b/src/DeckValidator.js
@@ -111,7 +111,8 @@ class DeckValidator {
             uniqueCards.push(deck.agenda);
         }
 
-        let restrictedResult = this.restrictedList.validate(uniqueCards);
+        let officialRestrictedResult = this.restrictedList.validate(uniqueCards, 'Official FAQ');
+        let worldcupRestrictedResult = this.restrictedList.validate(uniqueCards, 'Worldcup');
         let includesDraftCards = this.isDraftCard(deck.agenda) || allCards.some(cardQuantity => this.isDraftCard(cardQuantity.card));
 
         if(includesDraftCards) {
@@ -120,13 +121,16 @@ class DeckValidator {
 
         return {
             basicRules: errors.length === 0,
-            faqJoustRules: restrictedResult.validForJoust,
-            faqVersion: restrictedResult.version,
-            noBannedCards: restrictedResult.noBannedCards,
+            faqJoustRules: officialRestrictedResult.validForJoust,
+            faqVersion: officialRestrictedResult.version,
+            noBannedCards: officialRestrictedResult.noBannedCards,
+            worldcupJoustRules: worldcupRestrictedResult.validForJoust,
+            worldcupVersion: worldcupRestrictedResult.version,
+            worldcupNoBannedCards: worldcupRestrictedResult.noBannedCards,
             noUnreleasedCards: unreleasedCards.length === 0,
             plotCount: plotCount,
             drawCount: drawCount,
-            extendedStatus: errors.concat(unreleasedCards).concat(restrictedResult.errors)
+            extendedStatus: errors.concat(unreleasedCards).concat(officialRestrictedResult.errors).concat(worldcupRestrictedResult.errors)
         };
     }
 

--- a/src/RestrictedList.js
+++ b/src/RestrictedList.js
@@ -5,44 +5,29 @@ class RestrictedList {
         this.rules = rules;
     }
 
-    validate(cards, category) {
-        let currentRules = this.getCurrentRulesForCategory(category);
-        let joustCardsOnList = cards.filter(card => currentRules.joustCards.includes(card.code));
-        let bannedCardsOnList = cards.filter(card => currentRules.bannedCards.includes(card.code));
+    validate(cards) {
+        let restrictedCardsOnList = cards.filter(card => this.rules.restricted.includes(card.code));
+        let bannedCardsOnList = cards.filter(card => this.rules.banned.includes(card.code));
 
         let errors = [];
 
-        if(joustCardsOnList.length > 1) {
-            errors.push(`${category} v${currentRules.version}: Contains more than 1 card on the Joust restricted list: ${joustCardsOnList.map(card => card.name).join(', ')}`);
+        if(restrictedCardsOnList.length > 1) {
+            errors.push(`${this.rules.name}: Contains more than 1 card on the restricted list: ${restrictedCardsOnList.map(card => card.name).join(', ')}`);
         }
 
         if(bannedCardsOnList.length > 0) {
-            errors.push(`${category} v${currentRules.version}: Contains cards that are not tournament legal: ${bannedCardsOnList.map(card => card.name).join(', ')}`);
+            errors.push(`${this.rules.name}: Contains cards that are not tournament legal: ${bannedCardsOnList.map(card => card.name).join(', ')}`);
         }
 
         return {
-            category: category,
-            version: currentRules.version,
+            name: this.rules.name,
             valid: errors.length === 0,
-            validForJoust: joustCardsOnList.length <= 1,
+            restrictedRules: restrictedCardsOnList.length <= 1,
             noBannedCards: bannedCardsOnList.length === 0,
             errors: errors,
-            joustCards: joustCardsOnList,
+            restrictedCards: restrictedCardsOnList,
             bannedCards: bannedCardsOnList
         };
-    }
-
-    getCurrentRulesForCategory(category) {
-        let now = moment();
-        let filteredRules = this.rules.filter(rule => rule.category === category);
-        return filteredRules.reduce((max, list) => {
-            let effectiveDate = moment(list.date, 'YYYY-MM-DD');
-            if(effectiveDate <= now && effectiveDate > moment(max.date, 'YYYY-MM-DD')) {
-                return list;
-            }
-
-            return max;
-        });
     }
 }
 

--- a/src/RestrictedList.js
+++ b/src/RestrictedList.js
@@ -5,22 +5,23 @@ class RestrictedList {
         this.rules = rules;
     }
 
-    validate(cards) {
-        let currentRules = this.getCurrentRules();
+    validate(cards, category) {
+        let currentRules = this.getCurrentRulesForCategory(category);
         let joustCardsOnList = cards.filter(card => currentRules.joustCards.includes(card.code));
         let bannedCardsOnList = cards.filter(card => currentRules.bannedCards.includes(card.code));
 
         let errors = [];
 
         if(joustCardsOnList.length > 1) {
-            errors.push(`Contains more than 1 card on the FAQ v${currentRules.version} Joust restricted list: ${joustCardsOnList.map(card => card.name).join(', ')}`);
+            errors.push(`${category} v${currentRules.version}: Contains more than 1 card on the Joust restricted list: ${joustCardsOnList.map(card => card.name).join(', ')}`);
         }
 
         if(bannedCardsOnList.length > 0) {
-            errors.push(`Contains cards that are not tournament legal: ${bannedCardsOnList.map(card => card.name).join(', ')}`);
+            errors.push(`${category} v${currentRules.version}: Contains cards that are not tournament legal: ${bannedCardsOnList.map(card => card.name).join(', ')}`);
         }
 
         return {
+            category: category,
             version: currentRules.version,
             valid: errors.length === 0,
             validForJoust: joustCardsOnList.length <= 1,
@@ -31,9 +32,10 @@ class RestrictedList {
         };
     }
 
-    getCurrentRules() {
+    getCurrentRulesForCategory(category) {
         let now = moment();
-        return this.rules.reduce((max, list) => {
+        let filteredRules = this.rules.filter(rule => rule.category === category);
+        return filteredRules.reduce((max, list) => {
             let effectiveDate = moment(list.date, 'YYYY-MM-DD');
             if(effectiveDate <= now && effectiveDate > moment(max.date, 'YYYY-MM-DD')) {
                 return list;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ module.exports = {
     validateDeck: function(deck, options) {
         options = Object.assign({ includeExtendedStatus: true }, options);
 
-        let validator = new DeckValidator(options.packs, options.restrictedList);
+        let validator = new DeckValidator(options.packs, options.restrictedLists);
         let result = validator.validateDeck(deck);
 
         if(!options.includeExtendedStatus) {


### PR DESCRIPTION
The validate function of RestrictedList now uses a category parameter to validate the decks against different kinds of restricted lists.
The DeckValidator now validates decks for the Worldcup restricted lists and adds the Validation result to the response object